### PR TITLE
Support semantic versioning precedence

### DIFF
--- a/doc/source/release/release_notes.rst
+++ b/doc/source/release/release_notes.rst
@@ -8,6 +8,12 @@
 Release Notes
 *************
 
+.. release:: upcoming
+
+    .. change:: added
+
+        Support semantic versioning precedence.
+
 .. release:: 0.1.4
     :date: 2022-05-18
 

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ setup(
         'sphinx_rtd_theme >= 0.1.6, < 2',
         'lowdown >= 0.1.0, < 2',
         'setuptools>=45.0.0',
-        'setuptools_scm'
+        'setuptools_scm',
+        'packaging'
     ],
     tests_require=['pytest >= 2.3.5, < 3'],
     use_scm_version={

--- a/source/ftrack_connect_plugin_manager/__init__.py
+++ b/source/ftrack_connect_plugin_manager/__init__.py
@@ -8,7 +8,7 @@ import zipfile
 import tempfile
 import urllib
 from urllib.request import urlopen
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 import appdirs
 import json
 
@@ -197,7 +197,7 @@ class DndPluginList(QtWidgets.QFrame):
         plugin_item.setText('{} | {}'.format(data['name'], data['version']))
         plugin_item.setData(status, ROLES.PLUGIN_STATUS)
         plugin_item.setData(str(data['name']), ROLES.PLUGIN_NAME)
-        new_plugin_version = LooseVersion(data['version'])
+        new_plugin_version = parse_version(data['version'])
         plugin_item.setData(new_plugin_version, ROLES.PLUGIN_VERSION)
         plugin_item.setData(plugin_id, ROLES.PLUGIN_ID)
         plugin_item.setIcon(STATUS_ICONS[status])


### PR DESCRIPTION
Resolves : 

* CLICKUP-https://app.clickup.com/t/3rj6xmu

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [X] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

Support semantic versioning precedence - make sure that for example "1.0.0" is a higher version than "1.0.0b1"

## Test

Release a beta or RC to beta channel, then emulate a public release. The plugin manager should suggest there is a upgrade available. 
            